### PR TITLE
Enable multiprocess mode and support for private browsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
 	"description": "Bring back the tabs on bottom feature !",
 	"author": "Alexandre Le Foll",
 	"license": "MPL 2.0",
-	"version": "1.2.0",
+	"version": "1.3.0",
+	"permissions": {
+		"multiprocess": true,
+		"private-browsing": true
+	},
 	"preferences": [{
 		"type": "color",
 		"name": "otherTabsColor",


### PR DESCRIPTION
- Enabled e10s mode. The addon seems to be compatible without adaptions with stable and nightly versions of FF.
- Support for private browsing required an [explicit setting](https://developer.mozilla.org/en-US/Add-ons/SDK/High-Level_APIs/private-browsing#Opting_into_private_browsing). Also fixes #3  
