### PR TITLE
Fixed the title bar on OS X and wrong placement in new windows

### DIFF
--- a/data/tabs.css
+++ b/data/tabs.css
@@ -1,7 +1,7 @@
 @namespace url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
 
 #TabsToolbar {
-	-moz-box-ordinal-group: 2 !important;
+	-moz-box-ordinal-group: 21 !important;
 }
 
 #addon-bar {
@@ -16,7 +16,7 @@
 @media (-moz-os-version: windows-vista),
        (-moz-os-version: windows-win7) {
 	#TabsToolbar {
-		margin-top: 0px !important;
+		margin-top: 0 !important;
 	}
 
 	#nav-bar {
@@ -26,4 +26,14 @@
 	#toolbar-menubar[autohide="false"] ~ #nav-bar {
 		margin-top: 1px !important;
 	}
+}
+
+@supports (-moz-osx-font-smoothing:auto) {
+	#titlebar {
+		margin-bottom: 0 !important;
+	}
+}
+
+toolbar:not(#toolbar-menubar):not(#TabsToolbar):not(#addon-bar):not(#nav-bar) {
+	-moz-box-ordinal-group: 20 !important;
 }


### PR DESCRIPTION
Two issues:

1. The title bar is misplaced on OS X:
![os x](https://cloud.githubusercontent.com/assets/343448/22270249/005bb2f6-e28f-11e6-90ad-5b5cc953cac3.png)
Since it only affects OS X, the solution doesn't need to be applied to other platforms.

2. Upon opening a second window, the favourites bar suddenly becomes located above the nav bar. Curiously, opening the UI customization settings triggers a rearrangement (seems to be related or the same as in issue #4).
![favoritesbar](https://cloud.githubusercontent.com/assets/343448/22270770/746365ac-e291-11e6-8839-4f5ede83604f.png)
The solution fixes this issue so that the bars get correctly arranged also when a second window is opened.