### PR TITLE
Refactoring

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,89 +1,79 @@
-var events  = require('sdk/system/events');
-var prefs   = require('sdk/simple-prefs');
-var self    = require('sdk/self');
-var style   = require('sdk/stylesheet/utils');
-var windows = require('sdk/window/utils');
+"use strict";
 
-var { attachTo, detachFrom } = require("sdk/content/mod");
-var Style = require("sdk/stylesheet/style").Style;
+const prefs = require('sdk/simple-prefs');
+const self = require('sdk/self');
+const Style = require('sdk/stylesheet/style').Style;
+const tabs = require('sdk/tabs');
+const { attach, detach, attachTo, detachFrom } = require('sdk/content/mod');
+const { viewFor } = require('sdk/view/core');
+const { browserWindows } = require('sdk/windows');
 
-var prefOtherTabsColor = "otherTabsColor";
+const otherTabsShadow  = Style({ source: '.tabbrowser-tab:not([selected="true"]) { text-shadow: 0 0 3px }' });
+const TabsToolbarStyle = Style({ uri: self.data.url('tabs.css') });
+const newTabsSearchBar = Style({ uri: self.data.url('search_bar.css') });
+
 var otherTabsColor;
 
-var otherTabsShadow = Style({
-	source: '.tabbrowser-tab:not([selected="true"]) { text-shadow: 0 0 3px }'
-});
-
-var TabsToolbarStyle = Style({
-	uri: self.data.url('tabs.css')
-});
-
-var newTabsSearchBar = Style({
-	uri: self.data.url('search_bar.css')
-});
-
 function prefsUpdate() {
-	var listWindows = windows.windows();
-
-	for (var i = 0; i < listWindows.length; i++)
-		applyStyleOtherTabs(listWindows[i]);
+  Array.prototype.forEach.call(browserWindows, applyStyleOtherTabs);
+  searchBar(false);
 }
 
-function applyStyleOtherTabs(window) {
-	if(typeof otherTabsColor !== "undefined")
-		detachFrom(otherTabsColor, window);
-
-	otherTabsColor = Style({
-		source: '.tabbrowser-tab:not([selected="true"]) { color: ' + prefs.prefs[prefOtherTabsColor] + ' }'
-	});
-
-	attachTo(otherTabsColor, window);
-
-	if(prefs.prefs["otherTabsShadow"])
-		attachTo(otherTabsShadow, window);
-	else
-		detachFrom(otherTabsShadow, window);
-
-	if(prefs.prefs["searchBarNewTabPage"])
-		attachTo(newTabsSearchBar, window);
-	else
-		detachFrom(newTabsSearchBar, window);
+function addNewTabsSearchBarStyle() {
+  if (tabs.activeTab.url != 'about:newtab') return;
+  attach(newTabsSearchBar, tabs.activeTab);
 }
 
-function applyStyle(window) {
-	applyStyleOtherTabs(window);
-
-	attachTo(TabsToolbarStyle, window);
-
-	if(window.document.getElementById('toolbar-menubar') != null && window.document.getElementById('toolbar-menubar').getAttribute("autohide") == 'false')
-		window.document.getElementById('nav-bar').style.marginTop = "0px";
+function searchBar(initial) {
+  if (prefs.prefs['searchBarNewTabPage']) {
+    tabs.on('load', addNewTabsSearchBarStyle);
+    tabs.on('activate', addNewTabsSearchBarStyle);
+  } else if (!initial) {
+    tabs.off('load', addNewTabsSearchBarStyle);
+    tabs.off('activate', addNewTabsSearchBarStyle);
+    Array.prototype.forEach.call(tabs, (tab) => detach(newTabsSearchBar, tab));
+  }
 }
 
-function listener(event) {
-	applyStyle(event.subject.parent);
+function applyStyleOtherTabs(win) {
+  let window = viewFor(win);
+  if (typeof otherTabsColor !== "undefined")
+    detachFrom(otherTabsColor, window);
+
+  otherTabsColor = Style({ source: '.tabbrowser-tab:not([selected="true"]) { color: ' + prefs.prefs['otherTabsColor'] + ' }' });
+  attachTo(otherTabsColor, window);
+
+  if (prefs.prefs['otherTabsShadow'])
+    attachTo(otherTabsShadow, window);
+  else
+    detachFrom(otherTabsShadow, window);
 }
 
-events.on('chrome-document-global-created', listener);
+function applyStyle(win) {
+  applyStyleOtherTabs(win);
 
-exports.main = function (options, callbacks) {
-	prefs.on("", prefsUpdate);
+  let window = viewFor(win);
+  attachTo(TabsToolbarStyle, window);
 
-	var listWindows = windows.windows();
+  if (window.document.getElementById('toolbar-menubar') != null &&
+      window.document.getElementById('toolbar-menubar').getAttribute('autohide') == 'false') {
+    window.document.getElementById('nav-bar').style.marginTop = "0";
+  }
+}
 
-	for (var i = 0; i < listWindows.length; i++)
-		applyStyle(listWindows[i]);
+exports.main = (options, callbacks) => {
+  prefs.on("", prefsUpdate);
+
+  Array.prototype.forEach.call(browserWindows, applyStyle);
+  browserWindows.on('open', applyStyle);
+  searchBar(true);
 };
 
-exports.onUnload = function (reason) {
-	var listWindows = windows.windows();
-
-	for (var i = 0; i < listWindows.length; i++) {
-		detachFrom(TabsToolbarStyle, listWindows[i]);
-		detachFrom(otherTabsColor,   listWindows[i]);
-		detachFrom(otherTabsShadow,  listWindows[i]);
-		detachFrom(newTabsSearchBar, listWindows[i]);
-
-		if(prefs.prefs["searchBarNewTabPage"])
-			detachFrom(newTabsSearchBar, listWindows[i]);
-	}
+exports.onUnload = (reason) => {
+  Array.prototype.forEach.call(browserWindows, win => {
+    let window = viewFor(win);
+    detachFrom(TabsToolbarStyle, window);
+    detachFrom(otherTabsColor,   window);
+    detachFrom(otherTabsShadow,  window);
+  });
 };


### PR DESCRIPTION
**Preface**
I did some refactoring on the code when I just now saw that you have worked on Beta 2.0.0 at the very same time. What a pity! Nevertheless, I want to contribute my code even though it refers to 1.2.0.

Some explanation on my approach:

- Injecting the code into every loaded tab made no sense (every time the "chrome-document-global-created" event was fired). You also recognized this in Beta 2.0.0. 

- In terms of about:newtab, my solutions aims to only inject the code fragment _iff_ the page is loaded. Obviously, it makes no sense to add the CSS to all other pages. From what I see, this is still an issue in Beta 2.0.0 because a) it is still injected into every page and b) because it only works if a new windows is loaded with about:newtab but not if about:newtab is opened in any tab.

I would appreciate if you had a look on my refactored code. Of course, you can also copy everything if you want ;-) 